### PR TITLE
reset virtualProperties

### DIFF
--- a/src/Model/Behavior/InsertBehavior.php
+++ b/src/Model/Behavior/InsertBehavior.php
@@ -18,6 +18,7 @@ class InsertBehavior extends Behavior
     {
         $saveData = [];
         foreach ($entities as $entity) {
+            $entity->setVirtual([]);
             $saveData[] = $entity->toArray();
         }
 

--- a/src/Model/Behavior/UpsertBehavior.php
+++ b/src/Model/Behavior/UpsertBehavior.php
@@ -29,6 +29,7 @@ class UpsertBehavior extends Behavior
             throw new LogicException('config uniqueColumns is invalid.');
         }
 
+        $entity->setVirtual([]);
         $upsertData = $entity->toArray();
         $fields = array_keys($upsertData);
 
@@ -78,6 +79,7 @@ class UpsertBehavior extends Behavior
 
         $saveData = [];
         foreach ($entities as $entity) {
+            $entity->setVirtual([]);
             $saveData[] = $entity->toArray();
         }
 


### PR DESCRIPTION
Arrays include VirtualProperties.
Reset VirtualProperties.

reference
https://book.cakephp.org/3.0/en/orm/entities.html#exposing-virtual-properties
