### PR TITLE
Improve ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != 7.3 ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != '7.4snapshot' ]]; then phpenv config-rm xdebug.ini; fi
 
   - composer self-update
   - composer update --prefer-stable --prefer-dist --no-interaction $PREFER_LOWEST
@@ -56,7 +56,7 @@ before_script:
 
 script:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.3 ]]; then vendor/bin/phpunit; fi
-  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.3 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.3 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
 
   - if [[ $PHPCS = 1 ]]; then vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi
   - if [[ $PHPSTAN = 1 ]]; then vendor/bin/phpstan analyse -c phpstan.neon -l 7 src; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,21 @@ env:
     - DB=mysql db_dsn='mysql://travis@127.0.0.1/cakephp_test'
 
   global:
-    - DEFAULT=1
+    - DEFAULT=1 PREFER_LOWEST="--prefer-lowest"
 
 matrix:
   fast_finish: true
 
   include:
     - php: 7.3
-      env: PHPCS=1 DEFAULT=0
+      env: PREFER_LOWEST=""
 
     - php: 7.3
-      env: PHPSTAN=1 DEFAULT=0
+      env: PHPCS=1 DEFAULT=0 PREFER_LOWEST=" 
+
+    - php: 7.3
+      env: PHPSTAN=1 DEFAULT=0 PREFER_LOWEST=" 
+
 
 cache:
   directories:
@@ -37,7 +41,7 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION != 7.3 ]]; then phpenv config-rm xdebug.ini; fi
 
   - composer self-update
-  - composer install --prefer-dist --no-interaction
+  - composer update --prefer-stable --prefer-dist --no-interaction $PREFER_LOWEST
 
   - if [[ $DB = 'mysql' ]]; then mysql -e 'CREATE DATABASE cakephp_test; GRANT ALL PRIVILEGES ON cakephp_test.* TO travis@localhost;'; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: false
 
 env:
   matrix:
-    - DB=mysql db_dsn='mysql://travis@127.0.0.1/cakephp_test'
+    - DB=mysql db_user=root db_host=0.0.0.0 db_name=cakephp_test
 
   global:
     - DEFAULT=1 PREFER_LOWEST="--prefer-lowest"
@@ -23,10 +23,10 @@ matrix:
 
   include:
     - php: 7.3
-      env: PREFER_LOWEST=""
+      env: PREFER_LOWEST="" DB=mysql db_user=root db_host=0.0.0.0 db_name=cakephp_test
 
     - php: '7.4snapshot'
-      env: PREFER_LOWEST=""
+      env: PREFER_LOWEST="" DB=mysql db_user=root db_host=0.0.0.0 db_name=cakephp_test
 
     - php: 7.3
       env: PHPCS=1 DEFAULT=0 PREFER_LOWEST=" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
     - php: 7.3
       env: PREFER_LOWEST=""
 
+    - php: '7.4snapshot'
+      env: PREFER_LOWEST=""
+
     - php: 7.3
       env: PHPCS=1 DEFAULT=0 PREFER_LOWEST=" 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,9 @@ before_script:
   - if [[ $PHPCS = 1 ]]; then composer require cakephp/cakephp-codesniffer:"^3.0"; fi
   - if [[ $PHPSTAN = 1 ]]; then composer require phpstan/phpstan; fi
 
+  # see: https://github.com/cakephp/chronos/issues/106
+  - if [[ $TRAVIS_PHP_VERSION != 7.0 && $PREFER_LOWEST != "" ]]; then composer require  --prefer-stable --prefer-dist --no-interaction $PREFER_LOWEST cakephp/chronos:^1.0.1; fi
+
 script:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.3 ]]; then vendor/bin/phpunit; fi
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.3 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml; fi

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "require-dev": {
     "cakephp/cakephp": "^3.5",
-    "phpunit/phpunit": "^5.7"
+    "phpunit/phpunit": "^5.7.14|^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,4 +27,28 @@ if (file_exists($root . '/config/bootstrap.php')) {
 
     return;
 }
-require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
+
+// With PHP7.3 & CakePHP 3.5.0, StaticConfigTrait::parseDsn causes the error in preg_match
+// (It has benn fixed in 3.5.1 https://github.com/cakephp/cakephp/commit/91475ccfa58948b2561ffd9631664c1c3edaf300)
+// In place of using `db_dsn` uri, set db config with array.
+if (getenv('DB') === 'mysql') {
+    $dbConfig = [
+        'className' => \Cake\Database\Connection::class,
+        'driver' => \Cake\Database\Driver\Mysql::class,
+        'host' => getenv('db_host'),
+        'username' => getenv('db_user'),
+        'database' => getenv('db_name'),
+        'url' => null,
+    ];
+    \Cake\Datasource\ConnectionManager::setConfig('test', $dbConfig);
+    \Cake\Datasource\ConnectionManager::setConfig('test_custom_i18n_datasource', $dbConfig);
+    try {
+        require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
+    } catch (\BadMethodCallException $e) {
+        if (strpos($e->getMessage(), 'Cannot reconfigure existing key') !== 0) {
+            throw $e;
+        }
+    }
+} else {
+    require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
+}


### PR DESCRIPTION
I believe this pr would make the plugin more sustainable 💪 

- Check if run on min-ver. cakephp(3.5) in addition to current config as latest-ver only(3.8.x now).
- Check if run on PHP in early build(7.4)
- Generate code coverage with phpdbg alter to xdebug
    - see: https://docs.travis-ci.com/user/speeding-up-the-build/#php-optimizations