### PR TITLE
Updated to official travis php 74

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,6 @@ before_script:
   - if [[ $PHPCS = 1 ]]; then composer require cakephp/cakephp-codesniffer:"^3.0"; fi
   - if [[ $PHPSTAN = 1 ]]; then composer require phpstan/phpstan; fi
 
-  # see: https://github.com/cakephp/chronos/issues/106
-  - if [[ $TRAVIS_PHP_VERSION != 7.0 && $PREFER_LOWEST != "" ]]; then composer require  --prefer-stable --prefer-dist --no-interaction $PREFER_LOWEST cakephp/chronos:^1.0.1; fi
-
 script:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.4 ]]; then vendor/bin/phpunit; fi
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.4 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - mysql
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 sudo: false
 
@@ -22,16 +23,13 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 7.3
+    - php: 7.4
       env: PREFER_LOWEST="" DB=mysql db_user=root db_host=0.0.0.0 db_name=cakephp_test
 
-    - php: '7.4snapshot'
-      env: PREFER_LOWEST="" DB=mysql db_user=root db_host=0.0.0.0 db_name=cakephp_test
-
-    - php: 7.3
+    - php: 7.4
       env: PHPCS=1 DEFAULT=0 PREFER_LOWEST=""
 
-    - php: 7.3
+    - php: 7.4
       env: PHPSTAN=1 DEFAULT=0 PREFER_LOWEST=""
 
 
@@ -41,8 +39,6 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != '7.4snapshot' ]]; then phpenv config-rm xdebug.ini; fi
-
   - composer self-update
   - composer update --prefer-stable --prefer-dist --no-interaction $PREFER_LOWEST
 
@@ -55,15 +51,15 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION != 7.0 && $PREFER_LOWEST != "" ]]; then composer require  --prefer-stable --prefer-dist --no-interaction $PREFER_LOWEST cakephp/chronos:^1.0.1; fi
 
 script:
-  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.3 ]]; then vendor/bin/phpunit; fi
-  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.3 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.4 ]]; then vendor/bin/phpunit; fi
+  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.4 ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
 
   - if [[ $PHPCS = 1 ]]; then vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi
   - if [[ $PHPSTAN = 1 ]]; then vendor/bin/phpstan analyse -c phpstan.neon -l 7 src; fi
 
 after_success:
   - |
-    if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.3 ]]; then
+    if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.4 ]]; then
       curl -s https://codecov.io/bash > codecov
       sed -i -e 's/TRAVIS_.*_VERSION/^TRAVIS_.*_VERSION=/' codecov
       bash codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ matrix:
       env: PREFER_LOWEST="" DB=mysql db_user=root db_host=0.0.0.0 db_name=cakephp_test
 
     - php: 7.3
-      env: PHPCS=1 DEFAULT=0 PREFER_LOWEST=" 
+      env: PHPCS=1 DEFAULT=0 PREFER_LOWEST=""
 
     - php: 7.3
-      env: PHPSTAN=1 DEFAULT=0 PREFER_LOWEST=" 
+      env: PHPSTAN=1 DEFAULT=0 PREFER_LOWEST=""
 
 
 cache:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ CakePHP behavior plugin for easily some complicated queries.
 
 ## Requirements
 
-- PHP 7.0+
-- CakePHP 3.5+
+- PHP 7.1+
+- CakePHP 3.6+
 - MySQL 5.6+
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     "source": "https://github.com/itosho/easy-query"
   },
   "require": {
-    "cakephp/orm": "^3.5"
+    "cakephp/orm": "^3.6"
   },
   "require-dev": {
-    "cakephp/cakephp": "^3.5",
+    "cakephp/cakephp": "^3.6",
     "phpunit/phpunit": "^5.7.14|^6.0"
   },
   "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,3 @@
 parameters:
+    checkMissingIterableValueType: false
     ignoreErrors: []

--- a/src/Model/Behavior/InsertBehavior.php
+++ b/src/Model/Behavior/InsertBehavior.php
@@ -22,7 +22,7 @@ class InsertBehavior extends Behavior
      * @var array
      */
     protected $_defaultConfig = [
-        'event' => ['beforeSave' => true]
+        'event' => ['beforeSave' => true],
     ];
 
     /**
@@ -127,7 +127,7 @@ class InsertBehavior extends Behavior
         }
 
         $tmpTable = TableRegistry::getTableLocator()->get('tmp', [
-            'schema' => $this->_table->getSchema()
+            'schema' => $this->_table->getSchema(),
         ]);
         $query = $tmpTable
             ->find()

--- a/src/Model/Behavior/UpsertBehavior.php
+++ b/src/Model/Behavior/UpsertBehavior.php
@@ -21,7 +21,7 @@ class UpsertBehavior extends Behavior
     protected $_defaultConfig = [
         'updateColumns' => null,
         'uniqueColumns' => null,
-        'event' => ['beforeSave' => true]
+        'event' => ['beforeSave' => true],
     ];
 
     /**

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -14,8 +14,8 @@ class ArticlesFixture extends TestFixture
         'created' => 'datetime',
         'modified' => 'datetime',
         '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']]
-        ]
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
     ];
     public $records = [
         [
@@ -23,21 +23,21 @@ class ArticlesFixture extends TestFixture
             'body' => 'First Article Body',
             'published' => 1,
             'created' => '2017-09-01 00:00:00',
-            'modified' => '2017-09-01 00:00:00'
+            'modified' => '2017-09-01 00:00:00',
         ],
         [
             'title' => 'Second Article',
             'body' => 'Second Article Body',
             'published' => 1,
             'created' => '2017-09-01 00:00:00',
-            'modified' => '2017-09-01 00:00:00'
+            'modified' => '2017-09-01 00:00:00',
         ],
         [
             'title' => 'Third Article',
             'body' => 'Third Article Body',
             'published' => 1,
             'created' => '2017-09-01 00:00:00',
-            'modified' => '2017-09-01 00:00:00'
+            'modified' => '2017-09-01 00:00:00',
         ]
     ];
 }

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -38,6 +38,6 @@ class ArticlesFixture extends TestFixture
             'published' => 1,
             'created' => '2017-09-01 00:00:00',
             'modified' => '2017-09-01 00:00:00',
-        ]
+        ],
     ];
 }

--- a/tests/Fixture/TagsFixture.php
+++ b/tests/Fixture/TagsFixture.php
@@ -14,27 +14,27 @@ class TagsFixture extends TestFixture
         'modified' => 'datetime',
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
-            'unique' => ['type' => 'unique', 'columns' => ['name']]
-        ]
+            'unique' => ['type' => 'unique', 'columns' => ['name']],
+        ],
     ];
     public $records = [
         [
             'name' => 'tag1',
             'description' => 'tag1 description',
             'created' => '2017-09-01 00:00:00',
-            'modified' => '2017-09-01 00:00:00'
+            'modified' => '2017-09-01 00:00:00',
         ],
         [
             'name' => 'tag2',
             'description' => 'tag2 description',
             'created' => '2017-09-01 00:00:00',
-            'modified' => '2017-09-01 00:00:00'
+            'modified' => '2017-09-01 00:00:00',
         ],
         [
             'name' => 'tag3',
             'description' => 'tag3 description',
             'created' => '2017-09-01 00:00:00',
-            'modified' => '2017-09-01 00:00:00'
+            'modified' => '2017-09-01 00:00:00',
         ]
     ];
 }

--- a/tests/Fixture/TagsFixture.php
+++ b/tests/Fixture/TagsFixture.php
@@ -35,6 +35,6 @@ class TagsFixture extends TestFixture
             'description' => 'tag3 description',
             'created' => '2017-09-01 00:00:00',
             'modified' => '2017-09-01 00:00:00',
-        ]
+        ],
     ];
 }

--- a/tests/TestCase/Model/Behavior/InsertBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/InsertBehaviorTest.php
@@ -110,7 +110,7 @@ class InsertBehaviorTest extends TestCase
     {
         $this->Articles->removeBehavior('Insert');
         $this->Articles->addBehavior('Itosho/EasyQuery.Insert', [
-            'event' => ['beforeSave' => false]
+            'event' => ['beforeSave' => false],
         ]);
 
         $records = $this->getBaseInsertRecords();
@@ -159,7 +159,7 @@ class InsertBehaviorTest extends TestCase
         $newData = [
             'title' => 'New Article',
             'body' => 'New Article Body',
-            'published' => 1
+            'published' => 1,
         ];
         $entity = $this->Articles->newEntity($newData);
 
@@ -185,7 +185,7 @@ class InsertBehaviorTest extends TestCase
         $newData = [
             'title' => 'New Article',
             'body' => 'New Article Body',
-            'published' => 1
+            'published' => 1,
         ];
         $entity = $this->Articles->newEntity($newData);
         $now = FrozenTime::now();
@@ -209,7 +209,7 @@ class InsertBehaviorTest extends TestCase
         $duplicatedData = [
             'title' => 'First Article',
             'body' => 'First Article Body',
-            'published' => 1
+            'published' => 1,
         ];
         $entity = $this->Articles->newEntity($duplicatedData);
 
@@ -233,7 +233,7 @@ class InsertBehaviorTest extends TestCase
         $newData = [
             'title' => 'First Article',
             'body' => null,
-            'published' => 1
+            'published' => 1,
         ];
         $entity = $this->Articles->newEntity($newData);
 
@@ -244,7 +244,7 @@ class InsertBehaviorTest extends TestCase
             ->where([
                 'title' => 'First Article',
                 'body IS' => null,
-                'published' => 1
+                'published' => 1,
             ])
             ->all();
 
@@ -261,7 +261,7 @@ class InsertBehaviorTest extends TestCase
         $newData = [
             'title' => 'First Article',
             'body' => 'First Article Body',
-            'published' => 0
+            'published' => 0,
         ];
         $entity = $this->Articles->newEntity($newData);
 
@@ -276,7 +276,7 @@ class InsertBehaviorTest extends TestCase
             ->find()
             ->where([
                 'title' => 'First Article',
-                'body' => 'First Article Body'
+                'body' => 'First Article Body',
             ])
             ->all();
 
@@ -293,7 +293,7 @@ class InsertBehaviorTest extends TestCase
         $newData = [
             'title' => 'First Article',
             'body' => 'First Article Body',
-            'published' => 0
+            'published' => 0,
         ];
         $entity = $this->Articles->newEntity($newData);
 
@@ -323,17 +323,17 @@ class InsertBehaviorTest extends TestCase
             [
                 'title' => 'Fourth Article',
                 'body' => 'Fourth Article Body',
-                'published' => 1
+                'published' => 1,
             ],
             [
                 'title' => 'Fifth Article',
                 'body' => 'Fifth Article Body',
-                'published' => 1
+                'published' => 1,
             ],
             [
                 'title' => 'Sixth Article',
                 'body' => 'Sixth Article Body',
-                'published' => 1
+                'published' => 1,
             ]
         ];
     }

--- a/tests/TestCase/Model/Behavior/InsertBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/InsertBehaviorTest.php
@@ -334,7 +334,7 @@ class InsertBehaviorTest extends TestCase
                 'title' => 'Sixth Article',
                 'body' => 'Sixth Article Body',
                 'published' => 1,
-            ]
+            ],
         ];
     }
 }

--- a/tests/TestCase/Model/Behavior/UpsertBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UpsertBehaviorTest.php
@@ -34,7 +34,7 @@ class UpsertBehaviorTest extends TestCase
         $this->Tags = TableRegistry::getTableLocator()->get('Itosho/EasyQuery.Tags');
         $this->Tags->addBehavior('Itosho/EasyQuery.Upsert', [
             'uniqueColumns' => ['name'],
-            'updateColumns' => ['description', 'modified']
+            'updateColumns' => ['description', 'modified'],
         ]);
     }
 
@@ -60,7 +60,7 @@ class UpsertBehaviorTest extends TestCase
             'name' => 'tag4',
             'description' => 'tag4 description',
             'created' => $now,
-            'modified' => $now
+            'modified' => $now,
         ];
         $entity = $this->Tags->newEntity($record);
         $actual = $this->Tags->upsert($entity);
@@ -94,7 +94,7 @@ class UpsertBehaviorTest extends TestCase
 
         $record = [
             'name' => 'tag4',
-            'description' => 'tag4 description'
+            'description' => 'tag4 description',
         ];
         $now = Chronos::now();
         $expectedRecord = $record;
@@ -133,7 +133,7 @@ class UpsertBehaviorTest extends TestCase
             'name' => 'tag1',
             'description' => 'brand new tag1 description',
             'created' => '2017-10-01 00:00:00',
-            'modified' => '2017-10-01 00:00:00'
+            'modified' => '2017-10-01 00:00:00',
         ];
         $entity = $this->Tags->newEntity($record);
         $actual = $this->Tags->upsert($entity);
@@ -169,7 +169,7 @@ class UpsertBehaviorTest extends TestCase
 
         $record = [
             'name' => 'tag1',
-            'description' => 'brand new tag1 description'
+            'description' => 'brand new tag1 description',
         ];
         $now = Chronos::now();
         $currentCreated = '2017-09-01 00:00:00';
@@ -209,7 +209,7 @@ class UpsertBehaviorTest extends TestCase
         $this->Tags->addBehavior('Itosho/EasyQuery.Upsert', [
             'uniqueColumns' => ['name'],
             'updateColumns' => ['description', 'modified'],
-            'event' => ['beforeSave' => false]
+            'event' => ['beforeSave' => false],
         ]);
         $this->Tags->addBehavior('Timestamp');
 
@@ -245,14 +245,14 @@ class UpsertBehaviorTest extends TestCase
     {
         $this->Tags->removeBehavior('Upsert');
         $this->Tags->addBehavior('Itosho/EasyQuery.Upsert', [
-            'uniqueColumns' => ['name']
+            'uniqueColumns' => ['name'],
         ]);
 
         $data = [
             'name' => 'tag4',
             'description' => 'tag4 description',
             'created' => '2017-09-01 00:00:00',
-            'modified' => '2017-09-01 00:00:00'
+            'modified' => '2017-09-01 00:00:00',
         ];
         $entity = $this->Tags->newEntity($data);
         $this->Tags->upsert($entity);
@@ -269,14 +269,14 @@ class UpsertBehaviorTest extends TestCase
     {
         $this->Tags->removeBehavior('Upsert');
         $this->Tags->addBehavior('Itosho/EasyQuery.Upsert', [
-            'updateColumns' => ['description', 'modified']
+            'updateColumns' => ['description', 'modified'],
         ]);
 
         $data = [
             'name' => 'tag4',
             'description' => 'tag4 description',
             'created' => '2017-09-01 00:00:00',
-            'modified' => '2017-09-01 00:00:00'
+            'modified' => '2017-09-01 00:00:00',
         ];
         $entity = $this->Tags->newEntity($data);
         $this->Tags->upsert($entity);
@@ -291,7 +291,7 @@ class UpsertBehaviorTest extends TestCase
     {
         $this->Tags->removeBehavior('Upsert');
         $this->Tags->addBehavior('Itosho/EasyQuery.Upsert', [
-            'updateColumns' => ['description', 'modified']
+            'updateColumns' => ['description', 'modified'],
         ]);
 
         $records = $this->getBaseInsertRecords();
@@ -319,7 +319,7 @@ class UpsertBehaviorTest extends TestCase
     {
         $this->Tags->removeBehavior('Upsert');
         $this->Tags->addBehavior('Itosho/EasyQuery.Upsert', [
-            'updateColumns' => ['description', 'modified']
+            'updateColumns' => ['description', 'modified'],
         ]);
         $this->Tags->addBehavior('Timestamp');
 
@@ -349,7 +349,7 @@ class UpsertBehaviorTest extends TestCase
     {
         $this->Tags->removeBehavior('Upsert');
         $this->Tags->addBehavior('Itosho/EasyQuery.Upsert', [
-            'updateColumns' => ['description', 'modified']
+            'updateColumns' => ['description', 'modified'],
         ]);
 
         $records = $this->getBaseUpdateRecords();
@@ -379,7 +379,7 @@ class UpsertBehaviorTest extends TestCase
     {
         $this->Tags->removeBehavior('Upsert');
         $this->Tags->addBehavior('Itosho/EasyQuery.Upsert', [
-            'updateColumns' => ['description', 'modified']
+            'updateColumns' => ['description', 'modified'],
         ]);
         $this->Tags->addBehavior('Timestamp');
 
@@ -411,7 +411,7 @@ class UpsertBehaviorTest extends TestCase
         $this->Tags->removeBehavior('Upsert');
         $this->Tags->addBehavior('Itosho/EasyQuery.Upsert', [
             'updateColumns' => ['description', 'modified'],
-            'event' => ['beforeSave' => false]
+            'event' => ['beforeSave' => false],
         ]);
         $this->Tags->addBehavior('Timestamp');
 
@@ -465,7 +465,7 @@ class UpsertBehaviorTest extends TestCase
     {
         $this->Tags->removeBehavior('Upsert');
         $this->Tags->addBehavior('Itosho/EasyQuery.Upsert', [
-            'updateColumns' => ['description', 'modified']
+            'updateColumns' => ['description', 'modified'],
         ]);
 
         $this->Tags->bulkUpsert([]);
@@ -481,15 +481,15 @@ class UpsertBehaviorTest extends TestCase
         return [
             [
                 'name' => 'tag4',
-                'description' => 'tag4 description'
+                'description' => 'tag4 description',
             ],
             [
                 'name' => 'tag5',
-                'description' => 'tag5 description'
+                'description' => 'tag5 description',
             ],
             [
                 'name' => 'tag6',
-                'description' => 'tag6 description'
+                'description' => 'tag6 description',
             ]
         ];
     }
@@ -504,15 +504,15 @@ class UpsertBehaviorTest extends TestCase
         return [
             [
                 'name' => 'tag1',
-                'description' => 'brand new tag1 description'
+                'description' => 'brand new tag1 description',
             ],
             [
                 'name' => 'tag2',
-                'description' => 'brand new tag2 description'
+                'description' => 'brand new tag2 description',
             ],
             [
                 'name' => 'tag3',
-                'description' => 'brand new tag3 description'
+                'description' => 'brand new tag3 description',
             ]
         ];
     }

--- a/tests/TestCase/Model/Behavior/UpsertBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UpsertBehaviorTest.php
@@ -215,7 +215,7 @@ class UpsertBehaviorTest extends TestCase
 
         $record = [
             'name' => 'tag4',
-            'description' => 'tag4 description'
+            'description' => 'tag4 description',
         ];
         $expectedRecord = $record;
         $expectedRecord['created IS'] = null;
@@ -490,7 +490,7 @@ class UpsertBehaviorTest extends TestCase
             [
                 'name' => 'tag6',
                 'description' => 'tag6 description',
-            ]
+            ],
         ];
     }
 
@@ -513,7 +513,7 @@ class UpsertBehaviorTest extends TestCase
             [
                 'name' => 'tag3',
                 'description' => 'brand new tag3 description',
-            ]
+            ],
         ];
     }
 }


### PR DESCRIPTION
Now available PHP 7.4 in TravisCI.
So, remove snapshot version PHP, and change the default version(codecov, stan, cs) to 7.4.

[FYI]
phpstan recently changed to report "unspecified generic types" at level 6 and above.
In this PR, I don't touch about it(And CI failed). To workaround to it, you can add "ignoreErrors" in phpstan.neon.

see this: https://medium.com/@ondrejmirtes/phpstan-0-12-released-f1a88036535d